### PR TITLE
z_apply custom errors

### DIFF
--- a/src/z_validate.erl
+++ b/src/z_validate.erl
@@ -83,6 +83,7 @@ z_apply(Fun, ?Z_VALUE(_, Err)=ZVal) ->
 z_apply(Fun, ?Z_VALUE(Val, _Err), NewErr) ->
     case catch Fun(Val) of
         {ok, NewVal} -> ?Z_VALUE(NewVal, NewErr);
+        {error, Err} -> ?THROW_Z_ERROR(Err);
         _            -> ?THROW_Z_ERROR(NewErr)
     end.
 


### PR DESCRIPTION
One-line patch.
Allows z_apply to handle custom errors from arg funs, e.g.

```
a(X) when is_integer(X) -> {ok, X*2};
a(X) when is_atom(X) -> {error, atom_not_allowed};
a(X) when is_list(X) -> {error, lists_not_allowed}.

z_apply(fun a/1, z_wrap(123), {error, generic}), %% result is 246
z_apply(fun a/1, z_wrap(atom), {error, generic}), %% throws {error, atom_not_allowed}
z_apply(fun a/1, z_wrap([a,b,c]), {error, generic}), %% throws {error, lists_not_allowed} 
z_apply(fun a/1, z_wrap({illegal_pattern}), {error, generic}). %% throws {error, generic} because of pattern mismatch
```
